### PR TITLE
Fix the random color function in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import { Animate } from 'react-move'
   // Update your data to whatever you want
   data={{
     scale: Math.random() * 1,
-    color: ['red', 'blue', 'yellow'].find((d, i) => i === Math.round(Math.random() * 2)),
+    color: ['red', 'blue', 'yellow'][Math.floor(Math.random() * 3)],
     rotate: Math.random() > 0.5 ? 360 : 0
   }}
   duration={800}


### PR DESCRIPTION
`Math.round(Math.random() * 2)` might produce the following sequence: `2`, `2`, `0`. The find callback is called with `0`, `1`, `2`, so in that case, it would return `undefined`.

Also, as [vanderZwan pointed out on HN](https://news.ycombinator.com/item?id=14145978), you should use `Math.floor` instead of `Math.round`, because `Math.round` skews the probability (red: 25%, yellow: 25%, blue: 50%).

Also, if `null` should be a valid result, then I think it's better to be explicit:

```js
['red', 'blue', 'yellow', null][Math.floor(Math.random() * 4)]
```

(P.S. Sorry, I was bored, and this is a cool library!)