### PR TITLE
Move react type definitions to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "docs": "build-storybook -o docs && cp .storybook/CNAME docs/CNAME"
   },
   "dependencies": {
-    "@types/react": "^15.0.22",
     "d3-ease": "^1.0.3",
     "d3-interpolate": "^1.1.3",
     "performance-now": "^2.1.0",
     "raf": "^3.3.0"
   },
   "peerDependencies": {
+    "@types/react": "^15.0.22",
     "react": "^15.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

I was hoping to make the small change of moving the @types/react into a peer dependency. I think this has two benefits. First, that people not using typescript would no longer be forced to download the definitions. Second, there is a possible issue when having multiple different versions of the definitions. This change should resolve that.

Many thanks