### PR TITLE
Adds Appear To Exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import Animate from './Animate'
+import Appear from './Appear'
 import Transition from './Transition'
 
 module.exports = {
   Animate,
+  Appear,
   Transition,
 }


### PR DESCRIPTION
Imports and re-exports Appear component in src/Appear.js to make
available for use via `import {Appear} from "react-move"`.

Have been trying to use the Appear component as documented and was getting invariant violations.